### PR TITLE
Fixed create-project script to fetch the new updates

### DIFF
--- a/create-project.py
+++ b/create-project.py
@@ -41,9 +41,9 @@ app_path = "/" + "/".join(app_id.split(".")) + "/"
 current_dir = Path(os.getcwd())
 project_dir = current_dir / project_name
 
-files_url = "https://github.com/Relm4/relm4-template/archive/refs/tags/v0.1.0.zip"
+files_url = "https://github.com/Relm4/relm4-template/archive/refs/tags/v0.1.1.zip"
 zip_path = current_dir / "relm4-template.zip"
-template_path = current_dir / "relm4-template-0.1.0"
+template_path = current_dir / "relm4-template-0.1.1"
 online = len(sys.argv) >= 2 and sys.argv[1] == "--online"
 
 CURRENT_APP_ID = "com.belmoussaoui.GtkRustTemplate"


### PR DESCRIPTION
Currently, it fetches an old version of that template which uses relm4 0.5.1, so I updated the URL to fetch the release 0.1.1 because the current one is outdated. 

Also need to publish a new release for that to work :)