### PR TITLE
Fix: create-project fails due to missing setup.rs

### DIFF
--- a/create-project.py
+++ b/create-project.py
@@ -116,7 +116,6 @@ files_with_content_to_rename = [
     Path("po") / "POTFILES.in",
     Path("src") / "app.rs",
     Path("src") / "main.rs",
-    Path("src") / "setup.rs",
     Path("src") / "modals" / "about.rs",
     Path("Cargo.toml"),
     Path("meson.build"),


### PR DESCRIPTION
The script currently fails because it tries to copy setup.rs, which was deleted. This pull request removes the line attempting to copy the deleted file.