### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ flatpak-builder --user flatpak_app build-aux/<application_id>.Devel.json
 
 ## Running the project
 
-Once the project is build, run the command below. Replace Replace `<application_id>` and `<project_name>` with the values you entered during project creation. Please note that these commands are just for demonstration purposes. Normally this would be handled by your IDE, such as GNOME Builder or VS Code with the Flatpak extension.
+Once the project is build, run the command below. Replace `<application_id>` and `<project_name>` with the values you entered during project creation. Please note that these commands are just for demonstration purposes. Normally this would be handled by your IDE, such as GNOME Builder or VS Code with the Flatpak extension.
 
 ```shell
 flatpak-builder --run flatpak_app build-aux/<application_id>.Devel.json <project_name>


### PR DESCRIPTION
Word "Replace" is used twice by mistake.