### PR TITLE
Support development with NixOS

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@
 /vendor
 /.vscode
 .flatpak-builder/
+result
+.direnv

--- a/README.md
+++ b/README.md
@@ -65,12 +65,24 @@ flatpak install --user org.gnome.Sdk//46 org.gnome.Platform//46  org.freedesktop
 flatpak-builder --user flatpak_app build-aux/<application_id>.Devel.json
 ```
 
+### NixOS 
+```bash
+nix build . --show-trace
+```
+
 ## Running the project
 
 Once the project is build, run the command below. Replace `<application_id>` and `<project_name>` with the values you entered during project creation. Please note that these commands are just for demonstration purposes. Normally this would be handled by your IDE, such as GNOME Builder or VS Code with the Flatpak extension.
 
 ```shell
 flatpak-builder --run flatpak_app build-aux/<application_id>.Devel.json <project_name>
+```
+
+### NixOS
+```bash
+nix run 
+# or
+cd .. && ./relm4-template/result/bin/gtk-rust-template
 ```
 
 ## Translations with Gettext

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,72 @@
+{
+  pkgs ? let
+    lock = (builtins.fromJSON (builtins.readFile ./flake.lock)).nodes.nixpkgs.locked;
+    nixpkgs = fetchTarball {
+      url = "https://github.com/nixos/nixpkgs/archive/${lock.rev}.tar.gz";
+      sha256 = lock.narHash;
+    };
+  in
+    import nixpkgs {overlays = [];},
+  ...
+}: let
+  # Helpful nix function
+  getLibFolder = pkg: "${pkg}/lib";
+
+  # Manifest via Cargo.toml
+  manifest = (pkgs.lib.importTOML ./Cargo.toml).package;
+in
+  pkgs.stdenv.mkDerivation {
+    pname = manifest.name;
+    version = manifest.version;
+
+    src = pkgs.lib.cleanSource ./.;
+
+    cargoDeps = pkgs.rustPlatform.importCargoLock {
+      lockFile = ./Cargo.lock;
+      # Use this if you have dependencies from git instead
+      # of crates.io in your Cargo.toml
+      # outputHashes = {
+      #   # Sha256 of the git repository, doesn't matter if it's monorepo
+      #   "example-0.1.0" = "sha256-80EwvwMPY+rYyti8DMG4hGEpz/8Pya5TGjsbOBF0P0c=";
+      # };
+    };
+
+    # Compile time dependencies
+    nativeBuildInputs = with pkgs; [
+      git
+      rustc
+      cargo
+      ninja
+      meson
+      clippy
+      gettext
+      pkg-config
+      rust-analyzer
+      wrapGAppsHook4
+      appstream-glib
+      desktop-file-utils
+      rustPlatform.cargoSetupHook
+    ];
+
+    # Runtime dependencies which will be shipped
+    # with nix package
+    buildInputs = with pkgs; [
+      gtk4
+      glib
+      openssl
+      libadwaita
+      gdk-pixbuf
+      gnome-desktop
+      adwaita-icon-theme
+      desktop-file-utils
+      rustPlatform.bindgenHook
+    ];
+
+    # Compiler LD variables
+    NIX_LDFLAGS = "-L${(getLibFolder pkgs.libiconv)}";
+    LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath [
+      pkgs.gcc
+      pkgs.libiconv
+      pkgs.llvmPackages.llvm
+    ];
+  }

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1766070988,
+        "narHash": "sha256-G/WVghka6c4bAzMhTwT2vjLccg/awmHkdKSd2JrycLc=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "c6245e83d836d0433170a16eb185cefe0572f8b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,29 @@
+{
+  description = "nixed gtk-rust-template";
+
+  inputs = {
+    # Fresh and new for testing
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+
+    # The flake-utils library
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = {
+    nixpkgs,
+    flake-utils,
+    ...
+  }:
+    flake-utils.lib.eachDefaultSystem (system: let
+      pkgs = import nixpkgs {inherit system;};
+    in {
+      # Nix script formatter
+      formatter = pkgs.alejandra;
+
+      # Development environment
+      devShells.default = import ./shell.nix {inherit pkgs;};
+
+      # Output package
+      packages.default = pkgs.callPackage ./. {inherit pkgs;};
+    });
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,46 @@
+{pkgs, ...}: let
+  # Manifest via Cargo.toml
+  manifest = (pkgs.lib.importTOML ./Cargo.toml).package;
+in
+  pkgs.stdenv.mkDerivation {
+    name = "${manifest.name}-dev";
+
+    # Compile time dependencies
+    nativeBuildInputs = with pkgs; [
+      # Hail the Nix
+      nixd
+      statix
+      deadnix
+      alejandra
+
+      # Rust
+      rustc
+      cargo
+      rustfmt
+      clippy
+      rust-analyzer
+      cargo-watch
+
+      # Other compile time dependencies
+      openssl
+
+      # Gnome related
+      gtk4
+      meson
+      ninja
+      parted
+      gettext
+      pkg-config
+      gdk-pixbuf
+      libadwaita
+      gnome-desktop
+      wrapGAppsHook4
+      desktop-file-utils
+      gobject-introspection
+      rustPlatform.bindgenHook
+    ];
+
+    # Set Environment Variables
+    RUST_BACKTRACE = "full";
+    RUST_SRC_PATH = "${pkgs.rust.packages.stable.rustPlatform.rustLibSrc}";
+  }


### PR DESCRIPTION
- Added default.nix and shell.nix with flakes
- Added how to build and run process inside README.md

Nixed template from: https://github.com/bleur-org/templates